### PR TITLE
Export `fromJson` function

### DIFF
--- a/src/Http.elm
+++ b/src/Http.elm
@@ -7,6 +7,7 @@ module Http
     , Settings, defaultSettings
     , Response, Value(..)
     , Error(..), RawError(..)
+    , fromJson
     ) where
 {-|
 


### PR DESCRIPTION
Fixes https://github.com/evancz/elm-http/issues/2

The `fromJson` function is actually documented but not exported. This PR fixes the issue by exporting `fromJson`.
