### PR TITLE
Add response body to BadResponse

### DIFF
--- a/src/Http.elm
+++ b/src/Http.elm
@@ -294,14 +294,15 @@ type RawError
 
 {-| The kinds of errors you typically want in practice. When you get a
 response but its status is not in the 200 range, it will trigger a
-`BadResponse`. When you try to decode JSON but something goes wrong,
-you will get an `UnexpectedPayload`.
+`BadResponse` containing status code, status text and response body. 
+When you try to decode JSON but something goes wrong, you will get an 
+`UnexpectedPayload`.
 -}
 type Error
     = Timeout
     | NetworkError
     | UnexpectedPayload String
-    | BadResponse Int String
+    | BadResponse Int String String
 
 
 -- ACTUALLY SEND REQUESTS
@@ -418,7 +419,7 @@ handleResponse : (String -> Task Error a) -> Response -> Task Error a
 handleResponse handle response =
   case 200 <= response.status && response.status < 300 of
     False ->
-        fail (BadResponse response.status response.statusText)
+        fail (BadResponse response.status response.statusText response.body)
 
     True ->
         case response.value of

--- a/src/Http.elm
+++ b/src/Http.elm
@@ -294,7 +294,7 @@ type RawError
 
 {-| The kinds of errors you typically want in practice. When you get a
 response but its status is not in the 200 range, it will trigger a
-`BadResponse` containing status code, status text and response body. 
+`BadResponse` containing status code, status text and value (response body). 
 When you try to decode JSON but something goes wrong, you will get an 
 `UnexpectedPayload`.
 -}
@@ -302,7 +302,7 @@ type Error
     = Timeout
     | NetworkError
     | UnexpectedPayload String
-    | BadResponse Int String String
+    | BadResponse Int String Value
 
 
 -- ACTUALLY SEND REQUESTS
@@ -419,7 +419,7 @@ handleResponse : (String -> Task Error a) -> Response -> Task Error a
 handleResponse handle response =
   case 200 <= response.status && response.status < 300 of
     False ->
-        fail (BadResponse response.status response.statusText response.body)
+        fail (BadResponse response.status response.statusText response.value)
 
     True ->
         case response.value of


### PR DESCRIPTION
Handling response body in case of 400 Bad Request is a common use case (form handling), so instead of having to write its own `fromJson` function, we can add response body to BadResponse error type for later decoding.
