### PR TITLE
Fix toResponse

### DIFF
--- a/src/Native/Http.js
+++ b/src/Native/Http.js
@@ -89,13 +89,14 @@ Elm.Native.Http.make = function(localRuntime) {
 	function toResponse(req)
 	{
 		var tag = req.responseType === 'blob' ? 'Blob' : 'Text'
+		var response = tag === 'Blob' ? req.response : req.responseText;
 		return {
 			_: {},
 			status: req.status,
 			statusText: req.statusText,
 			headers: parseHeaders(req.getAllResponseHeaders()),
 			url: req.responseURL,
-			value: { ctor: tag, _0: req.response }
+			value: { ctor: tag, _0: response }
 		};
 	}
 

--- a/src/Native/Http.js
+++ b/src/Native/Http.js
@@ -88,7 +88,7 @@ Elm.Native.Http.make = function(localRuntime) {
 
 	function toResponse(req)
 	{
-		var tag = typeof req.response === 'string' ? 'Text' : 'Blob';
+		var tag = req.responseType === 'blob' ? 'Blob' : 'Text'
 		return {
 			_: {},
 			status: req.status,


### PR DESCRIPTION
My default stance on older browsers breaking is to say "use a polyfill," but this seems to be a case where we're relying on unspecified behavior, and following the spec more closely fixes IE9, so I made this PR.

Currently `toResponse` uses [`XMLHttpRequest.response`](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest#xmlhttprequest-response) and `typeof` to infer whether it received a Blob or Text. This is not quite to spec, and unfortunately breaks in the normal Text case for Internet Explorer 9 (which does not support Blobs, and always has `response` set to `undefined`).

According to the spec, what we ought to do is inspect [`responseType`](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest#xmlhttprequest-responsetype) to tell what kind of response we got, and then if we got a text value, use the value of [`responseText`](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest#xmlhttprequest-responsetext) instead of `response` (which is apparently only coincidentally equivalent to `responseText` in modern browsers when we get Text back).

This PR makes that happen, and makes it so that IE9 works as expected for non-Blobs.
