### PR TITLE
Fix issue with using Http.Empty on IE 10/11

### DIFF
--- a/src/Native/Http.js
+++ b/src/Native/Http.js
@@ -77,14 +77,20 @@ Elm.Native.Http.make = function(localRuntime) {
 				req.overrideMimeType(settings.desiredResponseType._0);
 			}
 
-			// actuall send the request
+			// actually send the request
 			if(request.body.ctor === "BodyFormData")
 			{
 				req.send(request.body.formData)
 			}
 			else
 			{
-				req.send(request.body._0);
+				// if there is no contained value, just call send
+				if (typeof request.body._0 === "undefined"){
+					req.send();
+				}
+				else {
+					req.send(request.body._0);
+				}
 			}
 		});
 	}


### PR DESCRIPTION
# Motivation

On some browsers (it seems like IE 11 and 10), using `Http.send` with a body made by `Http.Empty` causes the request to send `undefined` to the server. 
# Cause

This is down to the fact that `Http.Empty` doesn't actually have a `._0`, causing `req.send(req.body._0)` to send "undefined" in some browsers. In others, nothing is sent. Go figure. 
# What I changed

Now it checks to make sure that if there is no `._0`. If there is no `._0`, then instead just call `.send()` with no arguments. Otherwise, call `req.send` with the body as an argument as usual.
# What to test

Calling `Http.send` or any derivative (get, post) where `{ body = Http.Empty }`
