### PR TITLE
add value of `withCredentials` to `defaultSettings` documentation

### DIFF
--- a/src/Http.elm
+++ b/src/Http.elm
@@ -241,6 +241,7 @@ type alias Settings =
     , onStart = Nothing
     , onProgress = Nothing
     , desiredResponseType = Nothing
+    , withCredentials = False
     }
 -}
 defaultSettings : Settings


### PR DESCRIPTION
The documentation for `defaultSettings` doesn't show the default value of `withCredentials`.

<img width="469" alt="screen shot 2016-02-04 at 4 29 25 pm" src="https://cloud.githubusercontent.com/assets/72027/12833224/7ef54014-cb5c-11e5-938a-be1116b7ca6b.png">

This adds it to the documentation.
