### PR TITLE
If a non-2xx response has a text response, return this in BadResponse instead of statusText

### DIFF
--- a/src/Http.elm
+++ b/src/Http.elm
@@ -443,8 +443,12 @@ handleResponse handle response =
             fail (UnexpectedPayload "Response body is a blob, expecting a string.")
 
   else
-
-      fail (BadResponse response.status response.statusText)
+      let
+        text = case response.value of
+          Text str -> str
+          _ -> response.statusText
+      in
+        fail (BadResponse response.status text)
 
 
 


### PR DESCRIPTION
This would be an easy fix for #27 and #12 
