### PR TITLE
Link to elm-lang/http in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # elm-http
 
+*Note: If you are using Elm 0.18 or later then you want [elm-lang/http](http://package.elm-lang.org/packages/elm-lang/http/latest).*
+
 Make HTTP requests in Elm.
 
 The `Http` module aims to cover some of the most common cases of requesting


### PR DESCRIPTION
This package (`evancz/elm-http`) is the top google search result for "elm http", but almost certainly users are looking for `elm-lang/http` instead.  Point them to the new location.

I'm not the first to have this confusion:  https://groups.google.com/forum/#!topic/elm-discuss/nEsmgh4LD4A